### PR TITLE
Added throttle method to SimpleStateNotifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.1.6
 
-Added throttle method to SimpleStateNotifier
+Added throttle method to SimpleStateNotifier, renamed BaseWidget's onFailure callback to onGlobalFailure
 
 ## 0.1.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.6
+
+Added throttle method to SimpleStateNotifier
+
 ## 0.1.5
 
 Added optional scrollbarWidgetBuilder and scrollController parameters to PaginatedListView

--- a/README.md
+++ b/README.md
@@ -439,8 +439,8 @@ final class Data<State> extends BaseState<State> {
 
 Abstract StateNotifier class which provides some convenient methods to be used by subclassing it. It
 can be used when BaseState doesn't suit you and you need more states, this notifier has **showGlobalLoading**, 
-**clearGlobalLoading**, **setGlobalFailure**, **on**, **debounce** and **throttle** methods that are marked as **@protected** 
-so you can easily use them in your subclasses.
+**clearGlobalLoading**, **setGlobalFailure**, **on**, **debounce**, **throttle** and **cancelThrottle** methods 
+that are marked as **@protected** so you can easily use them in your subclasses.
 
 * **showGlobalLoading** & **clearGlobalLoading** for handling global loading
 
@@ -452,6 +452,8 @@ so you can easily use them in your subclasses.
 * **debounce** for waiting multiple method calls before only one method call can be executed
 
 * **throttle** for executing only first method call for some duration when there are multiple method calls
+
+* **cancelThrottle** for canceling throttling if in progress
 
 ## BaseStateNotifier
 

--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ final class Data<State> extends BaseState<State> {
 
 Abstract StateNotifier class which provides some convenient methods to be used by subclassing it. It
 can be used when BaseState doesn't suit you and you need more states, this notifier has **showGlobalLoading**, 
-**clearGlobalLoading**, **setGlobalFailure**, **on** and debounce**** methods that are marked as **@protected** 
+**clearGlobalLoading**, **setGlobalFailure**, **on**, **debounce** and **throttle** methods that are marked as **@protected** 
 so you can easily use them in your subclasses.
 
 * **showGlobalLoading** & **clearGlobalLoading** for handling global loading
@@ -450,6 +450,8 @@ so you can easily use them in your subclasses.
 * **on** for subscribing to another notifier's state changes so you can react appropriately
 
 * **debounce** for waiting multiple method calls before only one method call can be executed
+
+* **throttle** for executing only first method call for some duration when there are multiple method calls
 
 ## BaseStateNotifier
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -7,7 +7,7 @@
 
 # The following line activates a set of recommended lints for Flutter apps,
 # packages, and plugins designed to encourage good coding practices.
-# include: package:flutter_lints/flutter.yaml
+include: package:flutter_lints/flutter.yaml
 
 linter:
   # The lint rules applied to this project can be customized in the

--- a/example_app/lib/presentation/widgets/message_displaying_base_widget.dart
+++ b/example_app/lib/presentation/widgets/message_displaying_base_widget.dart
@@ -11,7 +11,7 @@ class MessageDisplayingBaseWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BaseWidget(
-      onFailure: (failure) => ScaffoldMessenger.of(context).showSnackBar(
+      onGlobalFailure: (failure) => ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text('${failure.title} ${failure.error}'),
         ),

--- a/example_app/pubspec.lock
+++ b/example_app/pubspec.lock
@@ -218,10 +218,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_hooks
-      sha256: "6a126f703b89499818d73305e4ce1e3de33b4ae1c5512e3b8eab4b986f46774c"
+      sha256: "7c8db779c2d1010aa7f9ea3fbefe8f86524fcb87b69e8b0af31e1a4b55422dec"
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.6"
+    version: "0.20.3"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -425,7 +425,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.4"
+    version: "0.1.5"
   riverpod:
     dependency: transitive
     description:

--- a/lib/src/data/api_error_resolver.dart
+++ b/lib/src/data/api_error_resolver.dart
@@ -14,8 +14,9 @@ final class ApiErrorResolver implements ErrorResolver {
 
   @override
   Failure resolve<T>(Object error, [StackTrace? stackTrace]) {
-    if (error is! DioException)
+    if (error is! DioException) {
       return Failure.generic(error: error, stackTrace: stackTrace);
+    }
     final response = error.response;
     final key = statusCodeToFailure.keys
         .firstWhereOrNull((code) => code == response?.statusCode);

--- a/lib/src/data/api_error_resolver.dart
+++ b/lib/src/data/api_error_resolver.dart
@@ -1,6 +1,5 @@
 import 'package:dio/dio.dart';
 import 'package:q_architecture/q_architecture.dart';
-import 'package:q_architecture/src/extensions/iterable_extensions.dart';
 
 /// An implementation of the [ErrorResolver] interface.
 ///

--- a/lib/src/domain/notifiers/paginated_stream_notifier.dart
+++ b/lib/src/domain/notifiers/paginated_stream_notifier.dart
@@ -75,8 +75,9 @@ abstract class PaginatedStreamNotifier<Entity, Param>
         getListStreamOrFailure(page, parameter).listen((result) {
       result.fold(
         (failure) {
-          if (useGlobalFailure)
+          if (useGlobalFailure) {
             ref.read(globalFailureProvider.notifier).update((_) => failure);
+          }
           state = PaginatedState.error(updatedList, failure);
         },
         (paginatedList) {

--- a/lib/src/domain/notifiers/simple_state_notifier.dart
+++ b/lib/src/domain/notifiers/simple_state_notifier.dart
@@ -91,6 +91,7 @@ abstract class SimpleStateNotifier<T> extends StateNotifier<T> {
     _isThrottling = true;
     final functionCompleter = Completer();
     final throttleCompleter = Completer();
+    var durationFinished = false;
     final completeThrottle = () {
       if (mounted && !throttleCompleter.isCompleted) {
         _isThrottling = false;
@@ -100,14 +101,15 @@ abstract class SimpleStateNotifier<T> extends StateNotifier<T> {
     function().then(
       (value) {
         functionCompleter.complete();
-        completeThrottle();
+        if (durationFinished) completeThrottle();
       },
       onError: (error) {
         functionCompleter.completeError(error);
-        completeThrottle();
+        if (durationFinished) completeThrottle();
       },
     );
     Future.delayed(duration, () {
+      durationFinished = true;
       if (!waitForFunction || functionCompleter.isCompleted) {
         completeThrottle();
       }

--- a/lib/src/domain/notifiers/simple_state_notifier.dart
+++ b/lib/src/domain/notifiers/simple_state_notifier.dart
@@ -92,12 +92,13 @@ abstract class SimpleStateNotifier<T> extends StateNotifier<T> {
     final functionCompleter = Completer();
     final throttleCompleter = Completer();
     var durationFinished = false;
-    final completeThrottle = () {
+    void completeThrottle() {
       if (mounted && !throttleCompleter.isCompleted) {
         _isThrottling = false;
         throttleCompleter.complete();
       }
-    };
+    }
+
     function().then(
       (value) {
         functionCompleter.complete();

--- a/lib/src/domain/notifiers/simple_state_notifier.dart
+++ b/lib/src/domain/notifiers/simple_state_notifier.dart
@@ -119,4 +119,8 @@ abstract class SimpleStateNotifier<T> extends StateNotifier<T> {
       throttleCompleter.future,
     ]);
   }
+
+  ///Cancels if throttling is in progress
+  @protected
+  void cancelThrottle() => _isThrottling = false;
 }

--- a/lib/src/presentation/widgets/base_loading_indicator.dart
+++ b/lib/src/presentation/widgets/base_loading_indicator.dart
@@ -3,10 +3,7 @@ import 'package:flutter/material.dart';
 class BaseLoadingIndicator extends StatelessWidget {
   final String? text;
 
-  const BaseLoadingIndicator({
-    Key? key,
-    this.text,
-  }) : super(key: key);
+  const BaseLoadingIndicator({super.key, this.text});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/presentation/widgets/base_widget.dart
+++ b/lib/src/presentation/widgets/base_widget.dart
@@ -5,22 +5,22 @@ import 'package:q_architecture/q_architecture.dart';
 class BaseWidget extends ConsumerWidget {
   final Widget child;
   final Widget? loadingIndicator;
-  final Function(Failure) onFailure;
-  final Function(GlobalInfo) onGlobalInfo;
+  final Function(Failure failure) onGlobalFailure;
+  final Function(GlobalInfo globalInfo) onGlobalInfo;
 
   const BaseWidget({
     required this.child,
-    required this.onFailure,
+    required this.onGlobalFailure,
     required this.onGlobalInfo,
     this.loadingIndicator,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     ref.listen<Failure?>(globalFailureProvider, (_, failure) {
       if (failure == null) return;
-      onFailure(failure);
+      onGlobalFailure(failure);
     });
     ref.listen<GlobalInfo?>(globalInfoProvider, (_, globalInfo) {
       if (globalInfo == null) return;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: q_architecture
 description: >
   A set of reusable classes that should speed up your development time  and
   reduce unnecessary boilerplate code.
-version: 0.1.5
+version: 0.1.6
 repository: https://github.com/Q-Agency/Q-Architecture
 issue_tracker: https://github.com/Q-Agency/Q-Architecture/issues
 
@@ -10,18 +10,18 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  dio: ^5.3.2
+  dio: ^5.3.3
   either_dart: ^1.0.0
   equatable: ^2.0.5
   flutter:
     sdk: flutter
-  flutter_hooks: ^0.20.1
-  hooks_riverpod: ^2.4.0
+  flutter_hooks: ^0.20.3
+  hooks_riverpod: ^2.4.4
   state_notifier_test: ^0.0.10
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mocktail: ^1.0.0
+  mocktail: ^1.0.1
 
 flutter: null

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   state_notifier_test: ^0.0.10
 
 dev_dependencies:
+  flutter_lints: ^3.0.0
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.1

--- a/test/src/domain/notifiers/base_state_notifier_test.dart
+++ b/test/src/domain/notifiers/base_state_notifier_test.dart
@@ -20,7 +20,7 @@ void main() {
   ProviderContainer getProviderContainer() => ProviderContainer();
 
   EitherFailureOr<String> getSuccessfulResponse() async {
-    return Right('');
+    return const Right('');
   }
 
   EitherFailureOr<String> getFailureResponse() async {
@@ -28,9 +28,9 @@ void main() {
   }
 
   StreamFailureOr<String> getSuccessfulResponseStream() async* {
-    yield Right('a');
+    yield const Right('a');
     await 300.milliseconds;
-    yield Right('b');
+    yield const Right('b');
   }
 
   StreamFailureOr<String> getFailureResponseStream() async* {
@@ -38,7 +38,7 @@ void main() {
   }
 
   StreamFailureOr<String> getSuccessThenFailureResponseStream() async* {
-    yield Right('a');
+    yield const Right('a');
     await 300.milliseconds;
     yield Left(testGenericFailure);
   }


### PR DESCRIPTION
Added throttle method to SimpleStateNotifier because sometimes it can be useful to have some method called only first time and then block its execution for a certain duration or until first time method execution finishes.