### PR TITLE
Feature/record entity mapper

### DIFF
--- a/example/lib/data/mappers/example_gender_mapper.dart
+++ b/example/lib/data/mappers/example_gender_mapper.dart
@@ -7,7 +7,10 @@ import '../../domain/entities/example_gender.dart';
 
 final exampleGenderMapperProvider =
     Provider<EntityMapper<ExampleGender, String>>(
-  (_) => (genderString) => _exampleGenderMap[genderString]!,
+  (_) => (
+    responseMapper: (genderString) => _exampleGenderMap[genderString]!,
+    requestMapper: null,
+  ),
 );
 
 final _exampleGenderMap = {

--- a/example/lib/data/mappers/example_user_entity_mapper.dart
+++ b/example/lib/data/mappers/example_user_entity_mapper.dart
@@ -9,10 +9,13 @@ import 'example_gender_mapper.dart';
 
 final exampleUserEntityMapperProvider =
     Provider<EntityMapper<ExampleUser, ExampleUserResponse>>(
-  (ref) => (response) => ExampleUser(
+  (ref) => (
+    responseMapper: (response) => ExampleUser(
         response.firstName,
         response.lastName,
         response.birthday,
-        ref.read(exampleGenderMapperProvider)(response.gender),
+        ref.read(exampleGenderMapperProvider).responseMapper(response.gender),
       ),
+    requestMapper: null,
+  ),
 );

--- a/example/lib/data/repositories/example_repository.dart
+++ b/example/lib/data/repositories/example_repository.dart
@@ -47,7 +47,7 @@ class ExampleRepositoryImp
   EitherFailureOr<ExampleUser> apiCallExample() => execute(
         () async {
           final userResponse = await _apiClient.getUser();
-          final user = _userMapper(userResponse);
+          final user = _userMapper.responseMapper(userResponse);
           return Right(user);
         },
         errorResolver: exampleApiErrorResolver,

--- a/lib/src/data/mappers/entity_mapper.dart
+++ b/lib/src/data/mappers/entity_mapper.dart
@@ -1,1 +1,4 @@
-typedef EntityMapper<Entity, Response> = Entity Function(Response);
+typedef EntityMapper<Entity, Model> = ({
+  Entity Function(Model) responseMapper,
+  Model Function(Entity)? requestMapper,
+});


### PR DESCRIPTION
## Converted EntityMapper to use dart records

A common use case is that we are going to need to map an entity to a request model. It is quite tedious to inject another function into the repository for that scenario.

This way, we define a `responseMapper` together an optional `requestMapper` in the injected `EntityMapper`.

Check out the example for more 😸 